### PR TITLE
Fix bug where empty file showed '1 word'

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -48,7 +48,10 @@ class WordCounter {
             // Parse out unwanted whitespace so the split is accurate
             docContent = docContent.replace(/(< ([^>]+)<)/g, '').replace(/\s+/g, ' ');
             docContent = docContent.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
-            let wordCount = docContent.split(" ").length;
+            let wordCount = 0;
+            if (docContent != "") {
+                wordCount = docContent.split(" ").length;
+            }
 
             // Update the status bar
             this._statusBarMessage = window.setStatusBarMessage(wordCount !== 1 ? `${wordCount} Words` : '1 Word');


### PR DESCRIPTION
When a markdown file is empty the status bar shows '1 word'. I think this is because the array that is returned from docContent.split("") has length of 1. I added a check for an empty document before doing the split.
