### PR TITLE
Better word detection. Simpler splitting code.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -55,9 +55,10 @@ export class WordCounter {
     public _getWordCount(doc: TextDocument): number {
         let docContent = doc.getText();
 
-        // Parse out unwanted whitespace so the split is accurate
-        docContent = docContent.replace(/(< ([^>]+)<)/g, '').replace(/\s+/g, ' ');
-        docContent = docContent.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
+        // Simplify document text for an easier word detection
+        docContent = docContent.normalize('NFD').replace(/[\u0300-\u036F]/g, ''); // remove diacritics
+        docContent = docContent.replace(/(<([^>]+)>)/g, ''); // remove HTML tags
+        docContent = docContent.replace(/\W+/g, ' ').trim(); // separate words with a single space
         let wordCount = 0;
         if (docContent != "") {
             wordCount = docContent.split(" ").length;

--- a/extension.ts
+++ b/extension.ts
@@ -59,6 +59,7 @@ export class WordCounter {
         docContent = docContent.normalize('NFD').replace(/[\u0300-\u036F]/g, ''); // remove diacritics
         docContent = docContent.replace(/(<([^>]+)>)/g, ''); // remove HTML tags
         docContent = docContent.replace(/\W+/g, ' ').trim(); // separate words with a single space
+        
         let wordCount = 0;
         if (docContent != "") {
             wordCount = docContent.split(" ").length;


### PR DESCRIPTION
* Was the `/(< ([^>]+)<)/g` regex trying to delete HTML tags? If so, I fixed it
* The two last replacements do the same as `.trim()`
* With `normalize`+`replace` words with diacritics are counted properly. Not perfect, but usually enough for a few languages.

Fixes #13 and #14 (and not only for Spanish)