### PR TITLE
Fixing git image 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This is a simple extension that illustrates a number of concepts when it comes t
 
 It's pretty simple open up a `Markdown` file and the status bar will have an auto-updating wordcount in it...
 
-![Word Count in status bar](images/wordcount.gif)
+![Word Count in status bar](./images/wordcount.gif)


### PR DESCRIPTION
The gif image is not showing in VSCode (the URL results in a 404: https://github.com/Microsoft/vscode-wordcount/raw/master/images/wordcount.gif )

I think this change should probably fix the issue. 

![Screenshot 2021-12-02 at 12 42 45 PM](https://user-images.githubusercontent.com/1638325/144415741-f42122f0-dded-434b-957f-c022d9f95bdd.jpg)


